### PR TITLE
Npm package with umd version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.25
+
+### Added
+
+- Added UMD bundle into npm package.
+
 ## 1.0.24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "prepublishOnly": "npm run build && npm run test",
     "lint": "eslint src/ --fix",
-    "prebuild": "npm run clean",
-    "build": "tsc",
+    "prebuild": "npm run clean && npm run lint",
+    "build": "tsc && npm run build:umd",
     "build:es6": "tsc -m es6 --outDir dist/esm --moduleResolution node",
-    "build:webpack": "webpack --config webpack.config.js",
+    "build:umd": "webpack --config webpack.config.js",
     "clean": "rm -rf ./dist",
     "~build": "tsc --watch",
     "test": "TS_NODE_FILES=true mocha -r ts-node/register test/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/index.js",


### PR DESCRIPTION
Now package in npm also contains `bundle.umd.js` which can be used both in `node.js` and browser (even using `<script src="..."></script>` tag).