### PR TITLE
Renames private to secret where possible

### DIFF
--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -43,7 +43,7 @@ interface SignerTestingHelper {
   /**
    * Create an account (for testing)
    */
-  createTestAccount: (name: string, privateKey: string) => Promise<void>;
+  createTestAccount: (name: string, secretKey: string) => Promise<void>;
   /**
    * Return message ID so we can sign deploy programatically
    */

--- a/src/lib/CasperClient.ts
+++ b/src/lib/CasperClient.ts
@@ -38,7 +38,7 @@ export class CasperClient {
   }
 
   /**
-   * Load private key from file
+   * Load secret key from file
    *
    * @param path the path to the publicKey file
    * @param algo the signature algorithm of the file
@@ -58,38 +58,38 @@ export class CasperClient {
   }
 
   /**
-   * Load private key
-   * @param path the path to the private key file
+   * Load secret key
+   * @param path the path to the secret key file
    */
-  public loadPrivateKeyFromFile(
+  public loadSecretKeyFromFile(
     path: string,
     algo: SignatureAlgorithm
   ): Uint8Array {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.parsePrivateKeyFile(path);
+        return Keys.Ed25519.parseSecretKeyFile(path);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.parsePrivateKeyFile(path);
+        return Keys.Secp256K1.parseSecretKeyFile(path);
       default:
         throw new Error('Invalid signature algorithm');
     }
   }
 
   /**
-   * Load private key file to restore keyPair
+   * Load secret key file to restore keyPair
    *
-   * @param path The path to the private key
+   * @param path The path to the secret key
    * @param algo
    */
-  public loadKeyPairFromPrivateFile(
+  public loadKeyPairFromSecretFile(
     path: string,
     algo: SignatureAlgorithm
   ): AsymmetricKey {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.loadKeyPairFromPrivateFile(path);
+        return Keys.Ed25519.loadKeyPairFromSecretFile(path);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.loadKeyPairFromPrivateFile(path);
+        return Keys.Secp256K1.loadKeyPairFromSecretFile(path);
       default:
         throw new Error('Invalid signature algorithm');
     }
@@ -105,18 +105,18 @@ export class CasperClient {
   }
 
   /**
-   * Compute public key from private Key.
-   * @param privateKey
+   * Compute public key from secret Key.
+   * @param secretKey
    */
-  public privateToPublicKey(
-    privateKey: Uint8Array,
+  public SecretToPublicKey(
+    secretKey: Uint8Array,
     algo: SignatureAlgorithm
   ): Uint8Array {
     switch (algo) {
       case SignatureAlgorithm.Ed25519:
-        return Keys.Ed25519.privateToPublicKey(privateKey);
+        return Keys.Ed25519.secretToPublicKey(secretKey);
       case SignatureAlgorithm.Secp256K1:
-        return Keys.Secp256K1.privateToPublicKey(privateKey);
+        return Keys.Secp256K1.secretToPublicKey(secretKey);
       default:
         throw new Error('Invalid signature algorithm');
     }

--- a/src/lib/CasperClient.ts
+++ b/src/lib/CasperClient.ts
@@ -108,7 +108,7 @@ export class CasperClient {
    * Compute public key from secret Key.
    * @param secretKey
    */
-  public SecretToPublicKey(
+  public secretToPublicKey(
     secretKey: Uint8Array,
     algo: SignatureAlgorithm
   ): Uint8Array {

--- a/src/lib/CasperHDKey.ts
+++ b/src/lib/CasperHDKey.ts
@@ -33,11 +33,11 @@ export class CasperHDKey {
     return this.hdKey.publicKey;
   }
 
-  public privateKey() {
+  public secretKey() {
     return this.hdKey.privateKey;
   }
 
-  public privateExtendedKey() {
+  public secretExtendedKey() {
     return this.hdKey.privateExtendedKey;
   }
 

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -72,9 +72,9 @@ export const createNewVault: (password: string) => Promise<void> = (
 
 export const createTestAccount: (
   name: string,
-  privateKey: string
-) => Promise<void> = (name: string, privateKey: string) => {
-  return window.signerTestingHelper!.createTestAccount(name, privateKey);
+  secretKey: string
+) => Promise<void> = (name: string, secretKey: string) => {
+  return window.signerTestingHelper!.createTestAccount(name, secretKey);
 };
 
 export const getToSignMessageID: () => Promise<number | null> = () => {


### PR DESCRIPTION
To align with our naming convention elsewhere we need to replace references to 'private' keys with 'secret'.
Two of the dependencies (elliptic and key-encoder) used call them private keys however, this is internal to the methods in the file - all client facing methods have been renamed to remove private key.