### PR TITLE
Fix getBlockInfo, Add getBlockInfoByHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.32
+### Added
+
+- `CasperServiceByJsonRPC.getBlockInfoByHeight(height)`
+
+### Fixed
+
+- `CasperServiceByJsonRPC.getBlockInfo(hash)` to return requested block, not the last one.
+
 ## 1.0.25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -196,11 +196,36 @@ export class CasperServiceByJsonRPC {
     return await this.client.request({
       method: 'chain_get_block',
       params: {
-        block_hash: blockHashBase16
+        block_identifier: {
+          Hash: blockHashBase16
+        }
       }
+    }).then((res: GetBlockResult) => {
+      if (res.block !== null && res.block.hash !== blockHashBase16) {
+        throw new Error("Returned block does not have a matching hash.");
+      }
+      return res;
     });
   }
 
+  public async getBlockInfoByHeight(
+    height: number
+  ): Promise<GetBlockResult> {
+    return await this.client.request({
+      method: 'chain_get_block',
+      params: {
+        block_identifier: {
+          Height: height
+        }
+      }
+    }).then((res: GetBlockResult) => {
+      if (res.block !== null && res.block.header.height !== height) {
+        throw new Error("Returned block does not have a matching height.");
+      }
+      return res;
+    });
+  }
+  
   public async getLatestBlockInfo(): Promise<GetBlockResult> {
     return await this.client.request({
       method: 'chain_get_block'

--- a/test/nctl/RPC.test.ts
+++ b/test/nctl/RPC.test.ts
@@ -1,0 +1,32 @@
+import { assert } from 'chai';
+import { CasperServiceByJsonRPC } from '../../src/services';
+
+let client = new CasperServiceByJsonRPC(
+    'http://127.0.0.1:40101/rpc',
+);
+
+describe.skip('RPC', () => {
+    it('should return correct block by number', async () => {
+        let check = async (height: number) => {
+            let result = await client.getBlockInfoByHeight(height);
+            assert.equal(result.block?.header.height, height);
+        };
+        let blocks_to_check = 3;
+        for(let i = 0; i < blocks_to_check; i++) {
+            await check(i);
+        }
+    });
+
+    it('should return correct block by hash', async () => {
+        let check = async (height: number) => {
+            let block_by_height = await client.getBlockInfoByHeight(height);
+            let block_hash = block_by_height.block?.hash!;
+            let block = await client.getBlockInfo(block_hash);
+            assert.equal(block.block?.hash, block_hash);
+        };
+        let blocks_to_check = 3;
+        for(let i = 0; i < blocks_to_check; i++) {
+            await check(i);
+        }
+    });
+});


### PR DESCRIPTION
## 1.0.32
### Added

- `CasperServiceByJsonRPC.getBlockInfoByHeight(height)`

### Fixed

- `CasperServiceByJsonRPC.getBlockInfo(hash)` to return requested block, not the last one.
