### PR TITLE
Fix types and error handling for Signer methods

### DIFF
--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -2,7 +2,7 @@ interface CasperLabsHelper {
   /**
    * Returns connection status from Signer
    */
-  isConnected: () => Promise<boolean | undefined>;
+  isConnected: () => Promise<boolean>;
   /**
    * Attempt connection to Signer
    */
@@ -15,7 +15,7 @@ interface CasperLabsHelper {
    */
   sign: (messageBase16: string, publicKeyBase64?: string) => Promise<string>;
   // returns base64 encoded public key of user current selected account.
-  getSelectedPublicKeyBase64: () => Promise<string | undefined>;
+  getSelectedPublicKeyBase64: () => Promise<string>;
 }
 
 interface SignerTestingHelper {
@@ -30,7 +30,7 @@ interface SignerTestingHelper {
   /**
    * Check if there is an existing vault
    */
-  hasCreatedVault: () => Promise<boolean | undefined>;
+  hasCreatedVault: () => Promise<boolean>;
   /**
    * Reset existing vault (for testing) prevents complications
    * and unlocks in preparation for creating an account

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -8,7 +8,7 @@
 /**
  * Check whether CasperLabs Signer extension is connected
  */
-export const isConnected: () => Promise<boolean | undefined> = async () => {
+export const isConnected: () => Promise<boolean> = async () => {
   return await window.casperlabsHelper!.isConnected();
 };
 
@@ -24,10 +24,7 @@ export const sendConnectionRequest: () => void = () => {
  *
  * @throws Error if haven't connected to CasperLabs Signer browser extension.
  */
-export const getSelectedPublicKeyBase64: () => Promise<
-  string | undefined
-> = () => {
-  throwIfNotConnected();
+export const getSelectedPublicKeyBase64: () => Promise<string> = () => {
   return window.casperlabsHelper!.getSelectedPublicKeyBase64();
 };
 
@@ -44,7 +41,6 @@ export const sign: (
   messageBase16: string,
   publicKeyBase64?: string
 ) => Promise<string> = (messageBase16: string, publicKeyBase64?: string) => {
-  throwIfNotConnected();
   return window.casperlabsHelper!.sign(messageBase16, publicKeyBase64);
 };
 
@@ -56,7 +52,7 @@ export const forceDisconnect: () => void = () => {
   return window.signerTestingHelper!.forceDisconnect();
 };
 
-export const hasCreatedVault: () => Promise<boolean | undefined> = () => {
+export const hasCreatedVault: () => Promise<boolean> = () => {
   return window.signerTestingHelper!.hasCreatedVault();
 };
 
@@ -85,12 +81,4 @@ export const signTestDeploy: (msgId: number) => Promise<void> = (
   msgId: number
 ) => {
   return window.signerTestingHelper!.signTestDeploy(msgId);
-};
-
-const throwIfNotConnected = () => {
-  if (!isConnected()) {
-    throw new Error(
-      'No CasperLabs Signer browser plugin detected or it is not ready'
-    );
-  }
 };


### PR DESCRIPTION
The `undefined` type is not necessary in the SDK's Signer methods as the Signer code is now handling it along with handling requests when disconnected.
This change will allow the MAKE developers to clean up their types for the sake of integrating with the Signer.