### PR TITLE
Support getActivePublicKey from Signer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.42
+
+### Added
+
+- Support `getActivePublicKey` method from the Signer.
+
 ## 1.0.41
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -3,10 +3,12 @@ interface CasperLabsHelper {
    * Returns connection status from Signer
    */
   isConnected: () => Promise<boolean>;
+  
   /**
    * Attempt connection to Signer
    */
   requestConnection: () => void;
+  
   /**
    * send base16 encoded message to plugin to sign
    *
@@ -14,8 +16,17 @@ interface CasperLabsHelper {
    * @param publicKeyBase64 the base64 encoded public key used to sign the deploy, if set, we will check whether it is the same as the active key for signing the message, otherwise, we won't check.
    */
   sign: (messageBase16: string, publicKeyBase64?: string) => Promise<string>;
-  // returns base64 encoded public key of user current selected account.
+  
+  /*
+   * Returns base64 encoded public key of user current selected account.
+   */
   getSelectedPublicKeyBase64: () => Promise<string>;
+
+  /**
+   * Retrieve the active public key .
+   * @returns {string} Hex-encoded public key with algorithm prefix.
+   */
+   getActivePublicKey: () => Promise<string>;
 }
 
 interface SignerTestingHelper {


### PR DESCRIPTION
## 1.0.42

### Added

- Support `getActivePublicKey` method from the Signer.