### PR TITLE
Missing getActivePublicKey interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.43
+
+### Fixed
+
+- Missign interface for `getActivePublicKey` method from the Signer.
+
 ## 1.0.42
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -23,7 +23,7 @@ interface CasperLabsHelper {
   getSelectedPublicKeyBase64: () => Promise<string>;
 
   /**
-   * Retrieve the active public key .
+   * Retrieve the active public key.
    * @returns {string} Hex-encoded public key with algorithm prefix.
    */
    getActivePublicKey: () => Promise<string>;

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -29,6 +29,15 @@ export const getSelectedPublicKeyBase64: () => Promise<string> = () => {
 };
 
 /**
+ * Retrieve the active public key.
+ *
+ * @returns {string} Hex-encoded public key with algorithm prefix.
+ */
+export const getActivePublicKey: () => Promise<string> = () => {
+  return window.casperlabsHelper!.getActivePublicKey();
+};
+
+/**
  * send base16 encoded message to plugin to sign
  *
  * @param messageBase16 the base16 encoded message that plugin received to sign


### PR DESCRIPTION
## 1.0.43

### Fixed

- Missing interface for `getActivePublicKey` method from the Signer.