### PR TITLE
BIP44-Index update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0
+
+### Changed
+
+- BIP-44 Index changed from `748` to `506`. It follows https://github.com/satoshilabs/slips/blob/master/slip-0044.md. All secret and public keys dervied using `CasperHDKey` class will change.
+
 ## 1.1.0
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/lib/CasperHDKey.ts
+++ b/src/lib/CasperHDKey.ts
@@ -4,8 +4,8 @@ import { sha256 } from 'ethereum-cryptography/sha256';
 import { Secp256K1 } from './Keys';
 
 export class CasperHDKey {
-  // todo select a lucky number and register in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-  private readonly bip44Index = 748;
+  // Registered at https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+  private readonly bip44Index = 506;
 
   constructor(private hdKey: HDKeyT) {}
 


### PR DESCRIPTION
## 1.2.0

### Changed

- BIP-44 Index changed from `748` to `506`. It follows https://github.com/satoshilabs/slips/blob/master/slip-0044.md. All secret and public keys dervied using `CasperHDKey` class will change. 
