### PR TITLE
1.3.4 - Signer.getVersion returns running version of Signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.4
+
+## Added
+
+- `Signer.getVersion` returns running version of Signer.
+
 ## 1.3.3
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -1,5 +1,10 @@
 interface CasperLabsHelper {
   /**
+   * Returns Signer version
+   */
+  getVersion: () => string;
+
+  /**
    * Returns connection status from Signer
    */
   isConnected: () => Promise<boolean>;

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -2,7 +2,7 @@ interface CasperLabsHelper {
   /**
    * Returns Signer version
    */
-  getVersion: () => string;
+  getVersion: () => Promise<string>;
 
   /**
    * Returns connection status from Signer

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Returns Signer version
+ */
+export const getVersion: () => string = () => {
+  return window.casperlabsHelper!.getVersion();
+};
+
+/**
  * Check whether CasperLabs Signer extension is connected
  */
 export const isConnected: () => Promise<boolean> = async () => {

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -9,7 +9,11 @@
  * Returns Signer version
  */
 export const getVersion: () => string = () => {
-  return window.casperlabsHelper!.getVersion();
+  try {
+    return window.casperlabsHelper!.getVersion();
+  } catch {
+    return "<1.0.0";
+  }
 };
 
 /**

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -8,9 +8,9 @@
 /**
  * Returns Signer version
  */
-export const getVersion: () => string = () => {
+export const getVersion: () => Promise<string> = async () => {
   try {
-    return window.casperlabsHelper!.getVersion();
+    return await window.casperlabsHelper!.getVersion();
   } catch {
     return "<1.0.0";
   }


### PR DESCRIPTION
## Added

- `Signer.getVersion` returns running version of Signer.
