### PR TITLE
casper-client-sdk 1.4.0 - New Signer.Sign method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-client-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0
+
+## Changed
+
+- `Signer.sign` now requires deploy in JSON format, `public-key hex` of a sender and `public-key hex` of a target.
+
 ## 1.3.4
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-client-sdk",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "main": "dist/lib.node.js",

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -18,10 +18,10 @@ interface CasperLabsHelper {
    * Send Deploy in JSON format message to Signer plugin to sign.
    *
    * @param deploy deploy in JSON format
-   * @param sourcePublicKey base64 encoded public key used to sign the deploy
-   * @param targetPublicKey base64 encoded public key used to sign the deploy
+   * @param sourcePublicKeyHex public key in hex format with algorithm prefix. Used to sign the deploy
+   * @param targetPublicKeyHex public key in hex format with algorithm prefix. Used to display hex-formatted address on the UI
    */
-  sign: (deploy: JSON, sourcePublicKey: string, targetPublicKey: string) => Promise<JSON>;
+  sign: (deploy: any, sourcePublicKeyHex: string, targetPublicKeyHex: string) => Promise<JSON>;
   
   /*
    * Returns base64 encoded public key of user current selected account.

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -17,7 +17,7 @@ interface CasperLabsHelper {
   /**
    * Send Deploy in JSON format message to Signer plugin to sign.
    *
-   * @param messageBase16 the base16 encoded message that plugin received to sign
+   * @param deploy deploy in JSON format
    * @param sourcePublicKey base64 encoded public key used to sign the deploy
    * @param targetPublicKey base64 encoded public key used to sign the deploy
    */

--- a/src/@types/casperlabsSigner.d.ts
+++ b/src/@types/casperlabsSigner.d.ts
@@ -15,12 +15,13 @@ interface CasperLabsHelper {
   requestConnection: () => void;
   
   /**
-   * send base16 encoded message to plugin to sign
+   * Send Deploy in JSON format message to Signer plugin to sign.
    *
    * @param messageBase16 the base16 encoded message that plugin received to sign
-   * @param publicKeyBase64 the base64 encoded public key used to sign the deploy, if set, we will check whether it is the same as the active key for signing the message, otherwise, we won't check.
+   * @param sourcePublicKey base64 encoded public key used to sign the deploy
+   * @param targetPublicKey base64 encoded public key used to sign the deploy
    */
-  sign: (messageBase16: string, publicKeyBase64?: string) => Promise<string>;
+  sign: (deploy: JSON, sourcePublicKey: string, targetPublicKey: string) => Promise<JSON>;
   
   /*
    * Returns base64 encoded public key of user current selected account.

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -51,7 +51,7 @@ export const getActivePublicKey: () => Promise<string> = () => {
 /**
  * Send Deploy in JSON format message to Signer plugin to sign.
  *
- * @param messageBase16 the base16 encoded message that plugin received to sign
+ * @param deploy deploy in JSON format
  * @param sourcePublicKey base64 encoded public key used to sign the deploy
  * @param targetPublicKey base64 encoded public key used to sign the deploy
  *

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -49,19 +49,23 @@ export const getActivePublicKey: () => Promise<string> = () => {
 };
 
 /**
- * send base16 encoded message to plugin to sign
+ * Send Deploy in JSON format message to Signer plugin to sign.
  *
  * @param messageBase16 the base16 encoded message that plugin received to sign
- * @param publicKeyBase64 the base64 encoded public key used to sign the deploy, if set, we will check whether it is the same as the active key for signing the message, otherwise, we won't check.
+ * @param sourcePublicKey base64 encoded public key used to sign the deploy
+ * @param targetPublicKey base64 encoded public key used to sign the deploy
  *
  * @throws Error if haven't connected to CasperLabs Signer browser extension.
  * @throws Error if publicKeyBase64 is not the same as the key that Signer used to sign the message
  */
 export const sign: (
-  messageBase16: string,
-  publicKeyBase64?: string
-) => Promise<string> = (messageBase16: string, publicKeyBase64?: string) => {
-  return window.casperlabsHelper!.sign(messageBase16, publicKeyBase64);
+  deploy: JSON, 
+  sourcePublicKey: string, 
+  targetPublicKey: string
+) => Promise<JSON> = (
+  deploy: JSON, sourcePublicKey: string, targetPublicKey: string
+) => {
+  return window.casperlabsHelper!.sign(deploy, sourcePublicKey, targetPublicKey);
 };
 
 /*

--- a/src/lib/Signer.ts
+++ b/src/lib/Signer.ts
@@ -52,18 +52,19 @@ export const getActivePublicKey: () => Promise<string> = () => {
  * Send Deploy in JSON format message to Signer plugin to sign.
  *
  * @param deploy deploy in JSON format
- * @param sourcePublicKey base64 encoded public key used to sign the deploy
- * @param targetPublicKey base64 encoded public key used to sign the deploy
+ * @param sourcePublicKeyHex public key in hex format with algorithm prefix. Used to sign the deploy
+ * @param targetPublicKeyHex public key in hex format with algorithm prefix. Used to display hex-formatted address on the UI
  *
  * @throws Error if haven't connected to CasperLabs Signer browser extension.
- * @throws Error if publicKeyBase64 is not the same as the key that Signer used to sign the message
+ * @throws Error if sourcePublicKeyHex is not the same as the key that Signer used to sign the message
+ * @throws Error if targetPublicKeyHex is not the same as the key that is used as target in deploy.
  */
 export const sign: (
-  deploy: JSON, 
+  deploy: any, 
   sourcePublicKey: string, 
   targetPublicKey: string
-) => Promise<JSON> = (
-  deploy: JSON, sourcePublicKey: string, targetPublicKey: string
+) => Promise<any> = (
+  deploy: any, sourcePublicKey: string, targetPublicKey: string
 ) => {
   return window.casperlabsHelper!.sign(deploy, sourcePublicKey, targetPublicKey);
 };

--- a/test/lib/DeployUtil.test.ts
+++ b/test/lib/DeployUtil.test.ts
@@ -4,8 +4,8 @@ import { humanizerTTL, dehumanizerTTL } from '../../src/lib/DeployUtil';
 import { TypedJSON } from 'typedjson';
 
 const testDeploy = () => {
-  const senderKey = Keys.Ed25519.new();
-  const recipientKey = Keys.Ed25519.new();
+  const senderKey = Keys.Secp256K1.new();
+  const recipientKey = Keys.Secp256K1.new();
   const networkName = 'test-network';
   const paymentAmount = 10000000000000;
   const transferAmount = 10;
@@ -24,6 +24,7 @@ const testDeploy = () => {
   let payment = DeployUtil.standardPayment(paymentAmount);
   let deploy = DeployUtil.makeDeploy(deployParams, session, payment);
   deploy = DeployUtil.signDeploy(deploy, senderKey);
+  console.log(JSON.stringify(DeployUtil.deployToJson(deploy)));
   return deploy;
 }
 
@@ -420,5 +421,12 @@ describe('DeployUtil', () => {
 
     let result = Buffer.from(DeployUtil.deployToBytes(deploy!)).toString('hex');
     assert.equal(result, expected);
+  });
+
+  describe("xxx", () => {
+    console.log("HEY");
+    const deploy = DeployUtil.deployFromJson(JSON.parse(`{"deploy":{"hash":"5a323e12ff306b1bc6565ad7e4b4e135a1acd4aa583c2686e9e138af962c68a2","header":{"account":"02024ef1def792992eeed81b2c55c42420236700b9c0eb55229cfd31a5e1ef437ac4","timestamp":"2021-06-02T18:52:23.510Z","ttl":"30m","gas_price":1,"body_hash":"d995cec953d1cc0e21cdddafd6a24016334b544706e9e3669811431717c90d35","dependencies":[],"chain_name":"casper-test"},"payment":{"ModuleBytes":{"module_bytes":"","args":[["amount",{"cl_type":"U512","bytes":"0600a0724e1809","parsed":"null"}]]}},"session":{"Transfer":{"args":[["amount",{"cl_type":"U512","bytes":"0500f2052a01","parsed":"null"}],["target",{"cl_type":{"ByteArray":32},"bytes":"37f304a6632b214eacc45b85f6a45759194ea69f6684da0bca42d60e42ac8e12","parsed":"null"}],["id",{"cl_type":{"Option":"U64"},"bytes":"013e9e11ce79010000","parsed":"null"}]]}},"approvals":[{"signer":"02024ef1def792992eeed81b2c55c42420236700b9c0eb55229cfd31a5e1ef437ac4","signature":"02647b461570ee3ae1723189155148a969da57d6ebcf2653a55cfcacfd530c28330e540bfe5c3fb1b1aaee272bcf8267cae0685b941a4e869ec2a34170afa34dc0"}]}}`));
+
+    console.log(deploy);
   });
 });

--- a/test/lib/DeployUtil.test.ts
+++ b/test/lib/DeployUtil.test.ts
@@ -422,11 +422,4 @@ describe('DeployUtil', () => {
     let result = Buffer.from(DeployUtil.deployToBytes(deploy!)).toString('hex');
     assert.equal(result, expected);
   });
-
-  describe("xxx", () => {
-    console.log("HEY");
-    const deploy = DeployUtil.deployFromJson(JSON.parse(`{"deploy":{"hash":"5a323e12ff306b1bc6565ad7e4b4e135a1acd4aa583c2686e9e138af962c68a2","header":{"account":"02024ef1def792992eeed81b2c55c42420236700b9c0eb55229cfd31a5e1ef437ac4","timestamp":"2021-06-02T18:52:23.510Z","ttl":"30m","gas_price":1,"body_hash":"d995cec953d1cc0e21cdddafd6a24016334b544706e9e3669811431717c90d35","dependencies":[],"chain_name":"casper-test"},"payment":{"ModuleBytes":{"module_bytes":"","args":[["amount",{"cl_type":"U512","bytes":"0600a0724e1809","parsed":"null"}]]}},"session":{"Transfer":{"args":[["amount",{"cl_type":"U512","bytes":"0500f2052a01","parsed":"null"}],["target",{"cl_type":{"ByteArray":32},"bytes":"37f304a6632b214eacc45b85f6a45759194ea69f6684da0bca42d60e42ac8e12","parsed":"null"}],["id",{"cl_type":{"Option":"U64"},"bytes":"013e9e11ce79010000","parsed":"null"}]]}},"approvals":[{"signer":"02024ef1def792992eeed81b2c55c42420236700b9c0eb55229cfd31a5e1ef437ac4","signature":"02647b461570ee3ae1723189155148a969da57d6ebcf2653a55cfcacfd530c28330e540bfe5c3fb1b1aaee272bcf8267cae0685b941a4e869ec2a34170afa34dc0"}]}}`));
-
-    console.log(deploy);
-  });
 });

--- a/test/lib/DeployUtil.test.ts
+++ b/test/lib/DeployUtil.test.ts
@@ -4,8 +4,8 @@ import { humanizerTTL, dehumanizerTTL } from '../../src/lib/DeployUtil';
 import { TypedJSON } from 'typedjson';
 
 const testDeploy = () => {
-  const senderKey = Keys.Secp256K1.new();
-  const recipientKey = Keys.Secp256K1.new();
+  const senderKey = Keys.Ed25519.new();
+  const recipientKey = Keys.Ed25519.new();
   const networkName = 'test-network';
   const paymentAmount = 10000000000000;
   const transferAmount = 10;
@@ -24,7 +24,6 @@ const testDeploy = () => {
   let payment = DeployUtil.standardPayment(paymentAmount);
   let deploy = DeployUtil.makeDeploy(deployParams, session, payment);
   deploy = DeployUtil.signDeploy(deploy, senderKey);
-  console.log(JSON.stringify(DeployUtil.deployToJson(deploy)));
   return deploy;
 }
 


### PR DESCRIPTION
## 1.4.0

## Changed

- `Signer.sign` now requires deploy in JSON format, `public-key hex` of a sender and `public-key hex` of a target.