### PR TITLE
DeployUtil.deployFromJson to return Result<Deploy, Error>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1
+
+### Changed
+
+- `DeployUtil.deployFromJson` returns now `Result<Deploy, Error>` instead of `Deploy | undefined`. `Error` has a `message` inside.
+
 ## 2.0.0
 
 ### Changed
@@ -27,7 +33,6 @@ const myTypesComplex = {
 
 const myOkComplexRes = new CLResult( Ok(new CLList([new CLList([new CLU8(5), new CLU8(10), new CLU8(15)])])), myTypesComplex );
 ```
-
 
 - There are API changes in `CLOption` - now it requires `Some` or `None` wrappers as argument (from `ts-result` library).
 - Now all the serialization methods are not connected to `CLValue` anymore - `toJSON`, `fromJSON`, `toBytes`, `fromBytes` needs to be called with `CLValueParsers` eg. `CLValueParser.toJSON(CLValueBuilder.string("ABC"))`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/CasperClient.ts
+++ b/src/lib/CasperClient.ts
@@ -232,7 +232,7 @@ export class CasperClient {
     return await this.nodeClient
       .getDeployInfo(deployHash)
       .then((result: GetDeployResult) => {
-        return [DeployUtil.deployFromJson(result)!, result];
+        return [DeployUtil.deployFromJson(result).unwrap(), result];
       });
   }
 

--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -1146,7 +1146,7 @@ export const deployToJson = (deploy: Deploy) => {
  */
 export const deployFromJson = (json: any): Result<Deploy, Error> => {
   if (json.deploy === undefined) {
-    return new Err(new Error("The Deploy JSON doesn't have 'deploy' key."));
+    return new Err(new Error("The Deploy JSON doesn't have 'deploy' field."));
   }
   let deploy = null;
   try {
@@ -1157,16 +1157,12 @@ export const deployFromJson = (json: any): Result<Deploy, Error> => {
   }
 
   if (deploy === undefined || deploy === null) {
-    return Err(new Error("Can't parse to JSON"));
+    return Err(new Error("The JSON can't be parsed as a Deploy."));
   }
 
   const valid = validateDeploy(deploy);
   if (valid.err) {
     return new Err(new Error(valid.val));
-  }
-
-  if (!(deploy instanceof Deploy)) {
-    return new Err(new Error("'deploy' is not an instance of Deploy class."));
   }
 
   return new Ok(deploy);
@@ -1210,6 +1206,10 @@ export const deploySizeInBytes = (deploy: Deploy): number => {
 };
 
 export const validateDeploy = (deploy: Deploy): Result<Deploy, string> => {
+  if (!(deploy instanceof Deploy)) {
+    return new Err("'deploy' is not an instance of Deploy class.");
+  }
+
   const serializedBody = serializeBody(deploy.payment, deploy.session);
   const bodyHash = blake.blake2b(serializedBody, null, 32);
 

--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -1144,13 +1144,32 @@ export const deployToJson = (deploy: Deploy) => {
  *
  * @param json
  */
-export const deployFromJson = (json: any) => {
-  const serializer = new TypedJSON(Deploy);
-  const deploy = serializer.parse(json.deploy);
-  if (deploy !== undefined && validateDeploy(deploy).ok) {
-    return deploy;
+export const deployFromJson = (json: any): Result<Deploy, Error> => {
+  if (json.deploy === undefined) {
+    return new Err(new Error("The Deploy JSON doesn't have 'deploy' key."));
   }
-  return undefined;
+  let deploy = null;
+  try {
+    const serializer = new TypedJSON(Deploy);
+    deploy = serializer.parse(json.deploy);
+  } catch (serializationError) {
+    return new Err(serializationError);
+  }
+
+  if (deploy === undefined || deploy === null) {
+    return Err(new Error("Can't parse to JSON"));
+  }
+
+  const valid = validateDeploy(deploy);
+  if (valid.err) {
+    return new Err(new Error(valid.val));
+  }
+
+  if (!(deploy instanceof Deploy)) {
+    return new Err(new Error("'deploy' is not an instance of Deploy class."));
+  }
+
+  return new Ok(deploy);
 };
 
 export const addArgToDeploy = (

--- a/test/lib/CasperClient.test.ts
+++ b/test/lib/CasperClient.test.ts
@@ -208,7 +208,7 @@ describe('CasperClient', () => {
         }
       }
     };
-    const fromJson = casperClient.deployFromJson(json);
+    const fromJson = casperClient.deployFromJson(json).unwrap();
 
     expect(fromJson).to.be.an.instanceof(Deploy);
     expect(fromJson!.header.ttl).to.be.eq(1800000);

--- a/test/lib/DeployUtil.test.ts
+++ b/test/lib/DeployUtil.test.ts
@@ -72,7 +72,7 @@ describe('DeployUtil', () => {
     let json = DeployUtil.deployToJson(deploy);
 
     // Deserialize deploy from JSON.
-    deploy = DeployUtil.deployFromJson(json)!;
+    deploy = DeployUtil.deployFromJson(json).unwrap();
 
     assert.isTrue(deploy.isTransfer());
     assert.isTrue(deploy.isStandardPayment());
@@ -139,7 +139,7 @@ describe('DeployUtil', () => {
 
     // Serialize and deserialize deploy.
     let json = DeployUtil.deployToJson(deploy);
-    deploy = DeployUtil.deployFromJson(json)!;
+    deploy = DeployUtil.deployFromJson(json).unwrap();
 
     assert.deepEqual(
       deploy.session
@@ -244,7 +244,7 @@ describe('DeployUtil', () => {
 
     let newTransferDeploy = DeployUtil.deployFromJson(
       DeployUtil.deployToJson(transferDeploy)
-    );
+    ).unwrap();
 
     assert.deepEqual(
       newTransferDeploy?.session.getArgByName('fromPublicKey'),
@@ -256,7 +256,7 @@ describe('DeployUtil', () => {
     let deploy = testDeploy();
     let json = DeployUtil.deployToJson(deploy);
     Object.assign(json.deploy, { hash: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" });
-    assert.isUndefined(DeployUtil.deployFromJson(json));
+    assert.isTrue(DeployUtil.deployFromJson(json).err);
   });
 
   it('Should not allow for to deserialize a deploy from JSON with a wrong body_hash', function () {
@@ -265,7 +265,7 @@ describe('DeployUtil', () => {
     let header = Object(json.deploy)['header'];
     header['body_hash'] = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     Object.assign(json.deploy, { header });
-    assert.isUndefined(DeployUtil.deployFromJson(json));
+    assert.isTrue(DeployUtil.deployFromJson(json).err);
   });
 
   it('Should convert ms to humanized string', function () {
@@ -452,11 +452,11 @@ describe('DeployUtil', () => {
           }
         ]
       }
-    });
+    }).unwrap();
 
     let expected = "017f747b67bd3fe63c2a736739dfe40156d622347346e70f68f51c178a75ce5537a087c0377901000040771b00000000000200000000000000f2e0782bba4a0a9663cafc7d707fd4a74421bc5bfef4e368b7e8f38dfab87db8020000000f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f1010101010101010101010101010101010101010101010101010101010101010070000006d61696e6e6574d7a68bbe656a883d04bba9f26aa340dbe3f8ec99b2adb63b628f2bc92043199800000000000100000006000000616d6f756e74050000000400ca9a3b08050400000006000000616d6f756e740600000005005550b40508060000007461726765742000000001010101010101010101010101010101010101010101010101010101010101010f200000000200000069640900000001e7030000000000000d050f0000006164646974696f6e616c5f696e666f140000001000000074686973206973207472616e736665720a01000000017f747b67bd3fe63c2a736739dfe40156d622347346e70f68f51c178a75ce55370195a68b1a05731b7014e580b4c67a506e0339a7fffeaded9f24eb2e7f78b96bdd900b9be8ca33e4552a9a619dc4fc5e4e3a9f74a4b0537c14a5a8007d62a5dc06";
 
-    let result = Buffer.from(DeployUtil.deployToBytes(deploy!)).toString('hex');
+    let result = Buffer.from(DeployUtil.deployToBytes(deploy)).toString('hex');
 
     assert.equal(result, expected);
   });


### PR DESCRIPTION
## 2.0.1

### Changed

- `DeployUtil.deployFromJson` returns now `Result<Deploy, Error>` instead of `Deploy | undefined`. `Error` has a `message` inside.