### PR TITLE
casper-js-sdk 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.4
+
+## Fixed
+
+- Added better validation to `PublicKey.fromHex` method.
+
 ## 1.4.3
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/CLValue.ts
+++ b/src/lib/CLValue.ts
@@ -704,6 +704,11 @@ export class PublicKey extends CLTypedAndToBytes {
     if (publicKeyHex.length < 2) {
       throw new Error('asymmetric key error: too short');
     }
+    
+    if (!/^0[1,2][0-9a-f]{64}$/.test(publicKeyHex)) {
+      throw new Error('Invalid public key');
+    }
+    
     const publicKeyHexBytes = decodeBase16(publicKeyHex);
     switch (publicKeyHexBytes[0]) {
       case 1:

--- a/src/lib/CLValue.ts
+++ b/src/lib/CLValue.ts
@@ -705,7 +705,7 @@ export class PublicKey extends CLTypedAndToBytes {
       throw new Error('asymmetric key error: too short');
     }
     
-    if (!/^0[1,2][0-9a-f]{64}$/.test(publicKeyHex)) {
+    if (!/^0(1[0-9a-f]{64}|2[0-9a-f]{66})$/.test(publicKeyHex)) {
       throw new Error('Invalid public key');
     }
     


### PR DESCRIPTION
## 1.4.4

## Fixed

- Added better validation to `PublicKey.fromHex` method.
