### PR TITLE
Add a bundler config without polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const nodeExternals = require('webpack-node-externals');
 
 const common = {
   entry: './src/index.ts',
+  mode: 'production',
   module: {
     rules: [
       {
@@ -58,4 +59,21 @@ const clientConfig = {
   }
 };
 
-module.exports = [serverConfig, clientConfig];
+const bundlerConfig = {
+  ...common,
+  target: 'web',
+  resolve: {
+    ...common.resolve
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'lib.cjs.js',
+    libraryTarget: 'commonjs2'
+  },
+  externals: [nodeExternals()],
+  externalsPresets: {
+    node: true
+  }
+};
+
+module.exports = [serverConfig, clientConfig, bundlerConfig];


### PR DESCRIPTION
Currently, casper-js-sdk is our single biggest dependency and it's because it already contains polyfills for node builtins and they're duplicated from our other dependencies. It would be great if there is a build without polyfills built for web.