### PR TITLE
casper-js-sdk 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.7.1
+## 2.7.2
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.7.1
+
+### Fixed
+
+- Fix for bundling all of the existing types defined in the library.
+
 ## 2.7.0
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,6 +1744,50 @@
         }
       }
     },
+    "copy-webpack-plugin": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+      "integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5",
+        "glob-parent": "^6.0.0",
+        "globby": "^11.0.3",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.1.0",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.5.1",
+  "version": "2.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "buffer": "^6.0.3",
     "chai": "^4.2.0",
     "concurrently": "^6.0.0",
+    "copy-webpack-plugin": "^9.0.1",
     "crypto-browserify": "^3.12.0",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
@@ -71,6 +72,7 @@
     "pretty-quick": "^1.11.1",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
+    "stream-http": "^3.2.0",
     "ts-loader": "^8.0.17",
     "ts-node": "^8.4.1",
     "ts-protoc-gen": "^0.10.0",
@@ -78,10 +80,9 @@
     "tslint": "^6.1.3",
     "typedoc": "^0.17.8",
     "typescript": "^3.9.9",
-    "webpack-cli": "^4.5.0",
-    "webpack-node-externals": "^2.5.2",
     "url": "^0.11.0",
-    "stream-http": "^3.2.0"
+    "webpack-cli": "^4.5.0",
+    "webpack-node-externals": "^2.5.2"
   },
   "dependencies": {
     "@ethersproject/bignumber": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/RuntimeArgs.ts
+++ b/src/lib/RuntimeArgs.ts
@@ -14,7 +14,7 @@ import {
   resultHelper
 } from './CLValue';
 import { concat } from '@ethersproject/bytes';
-import { jsonMember, jsonObject } from 'typedjson';
+import { jsonMapMember, jsonObject } from 'typedjson';
 
 export class NamedArg implements ToBytes {
   constructor(public name: string, public value: CLValue) {}
@@ -58,7 +58,7 @@ const serRA = (map: Map<string, CLValue>) => {
 
 @jsonObject()
 export class RuntimeArgs implements ToBytes {
-  @jsonMember({
+  @jsonMapMember(String, CLValue, {
     serializer: serRA,
     deserializer: desRA
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
+const copyPlugin = require("copy-webpack-plugin");
 
 const common = {
   entry: './src/index.ts',
@@ -22,6 +23,13 @@ const common = {
 const serverConfig = {
   ...common,
   target: 'node',
+  plugins: [
+    new copyPlugin({
+      patterns: [
+        { from: "src/@types", to: "@types" },
+      ],
+    }),
+  ],
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'lib.node.js',
@@ -76,4 +84,4 @@ const bundlerConfig = {
   }
 };
 
-module.exports = [serverConfig, clientConfig, bundlerConfig];
+module.exports = [serverConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,4 +84,4 @@ const bundlerConfig = {
   }
 };
 
-module.exports = [serverConfig];
+module.exports = [serverConfig, clientConfig, bundlerConfig];


### PR DESCRIPTION
* fixes problem with missing types exported from library
* proper type for serialization of `RuntimeArgs` 