### PR TITLE
casper-js-sdk 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.7.1
+
+### Fixed
+
+- Adds support for mixed case hex representation of public keys introduced in `casper-node` `1.4.2`.
+
 ## 2.7.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Adds support for mixed case hex representation of public keys introduced in `casper-node` `1.4.2`.
+- Added support for mixed case hex representation of public keys introduced in `casper-node` `1.4.2`.
 
 ## 2.7.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/CLValue/PublicKey.test.ts
+++ b/src/lib/CLValue/PublicKey.test.ts
@@ -66,6 +66,14 @@ describe('CLPublicKey', () => {
 
     const badFn = () => CLPublicKey.fromHex('1');
     expect(badFn).to.throw('Asymmetric key error: too short');
+
+    // Check mixed case pubkeys
+    const goodFn = () =>
+      CLPublicKey.fromHex(
+        '0115C9b40c06fF99B0cBadf1140B061B5dBF92103E66a6330fbCc7768f5219C1ce'
+      );
+
+    expect(goodFn).to.not.throw();
   });
 
   it('CLPublicKey.fromEd25519() return proper value', () => {

--- a/src/lib/CLValue/PublicKey.ts
+++ b/src/lib/CLValue/PublicKey.ts
@@ -166,7 +166,7 @@ export class CLPublicKey extends CLValue {
     if (publicKeyHex.length < 2) {
       throw new Error('Asymmetric key error: too short');
     }
-    if (!/^0(1[0-9a-f]{64}|2[0-9a-f]{66})$/.test(publicKeyHex)) {
+    if (!/^0(1[0-9a-fA-F]{64}|2[0-9a-fA-F]{66})$/.test(publicKeyHex)) {
       throw new Error('Invalid public key');
     }
     const publicKeyHexBytes = decodeBase16(publicKeyHex);


### PR DESCRIPTION
## 2.7.1

### Fixed

- Added support for mixed case hex representation of public keys introduced in `casper-node 1.4.2`.
