### PR TITLE
Casper-js-sdk 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.7.4
+
+### Fixed
+
+- Fixes problems with `getBlockInfo` and mixed case block hashes.
+
 ## 2.7.3
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -234,7 +234,10 @@ export class CasperServiceByJsonRPC {
         }
       })
       .then((res: GetBlockResult) => {
-        if (res.block !== null && res.block.hash !== blockHashBase16) {
+        if (
+          res.block !== null &&
+          res.block.hash.toLowerCase() !== blockHashBase16.toLowerCase()
+        ) {
           throw new Error('Returned block does not have a matching hash.');
         }
         return res;


### PR DESCRIPTION
### Fixed

- Fixes problems with `getBlockInfo` and mixed case block hashes. Now user can paste both all lower-case hash or mixed case hash as a parameter.