### PR TITLE
casper-js-sdk 2.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.7.9
+
+### Fixed
+
+- Fixed problems with CLResult when it got created using different version of ts-results.
+
 ## 2.7.8
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/CLValue/Abstract.ts
+++ b/src/lib/CLValue/Abstract.ts
@@ -49,6 +49,9 @@ export abstract class ToBytes {
 }
 
 export abstract class CLValue {
+  isCLValue(): boolean {
+    return true;
+  }
   abstract clType(): CLType;
   abstract value(): any;
   abstract data: any;

--- a/src/lib/CLValue/Result.test.ts
+++ b/src/lib/CLValue/Result.test.ts
@@ -10,8 +10,10 @@ import {
   CLListType,
   CLList,
   CLOptionType,
-  CLOption
+  CLOption,
+  CLPublicKey
 } from './index';
+import { RuntimeArgs, decodeBase16, DeployUtil } from '../../index';
 import { Ok, Err, Some } from 'ts-results';
 
 const myTypes = { ok: new CLBoolType(), err: new CLU8Type() };
@@ -128,5 +130,33 @@ describe('CLResult', () => {
 
     expect(okFromBytes).to.be.deep.eq(myOkComplexRes);
     expect(errFromBytes).to.be.deep.eq(myErrComplexRes);
+  });
+
+  it('Complex examples toBytesWithCLType() / fromBytesWithCLType()', () => {
+    const args = RuntimeArgs.fromMap({
+      ResultOk: new CLResult(Ok(new CLBool(true)), myTypes),
+      ResultErr: new CLResult(Err(new CLU8(1)), myTypes)
+    });
+
+    const publicKey = CLPublicKey.fromHex(
+      '01a296024a9a978e8957acacd50e1889930f1ae2afe74dfd170ebf19593c492355'
+    );
+    const contractHash = decodeBase16(
+      '0116e3ba15cfbc4daafb2b43e2c26490015f7d6a1f575e69556251df3f7eb915'
+    );
+
+    const session = DeployUtil.ExecutableDeployItem.newStoredContractByHash(
+      contractHash,
+      'test-args',
+      args
+    );
+    const deployParams = new DeployUtil.DeployParams(publicKey, 'casper');
+
+    const d = DeployUtil.makeDeploy(
+      deployParams,
+      session,
+      DeployUtil.standardPayment(1000000)
+    );
+    console.log(DeployUtil.deployToJson(d));
   });
 });

--- a/src/lib/CLValue/Result.test.ts
+++ b/src/lib/CLValue/Result.test.ts
@@ -131,32 +131,4 @@ describe('CLResult', () => {
     expect(okFromBytes).to.be.deep.eq(myOkComplexRes);
     expect(errFromBytes).to.be.deep.eq(myErrComplexRes);
   });
-
-  it('Complex examples toBytesWithCLType() / fromBytesWithCLType()', () => {
-    const args = RuntimeArgs.fromMap({
-      ResultOk: new CLResult(Ok(new CLBool(true)), myTypes),
-      ResultErr: new CLResult(Err(new CLU8(1)), myTypes)
-    });
-
-    const publicKey = CLPublicKey.fromHex(
-      '01a296024a9a978e8957acacd50e1889930f1ae2afe74dfd170ebf19593c492355'
-    );
-    const contractHash = decodeBase16(
-      '0116e3ba15cfbc4daafb2b43e2c26490015f7d6a1f575e69556251df3f7eb915'
-    );
-
-    const session = DeployUtil.ExecutableDeployItem.newStoredContractByHash(
-      contractHash,
-      'test-args',
-      args
-    );
-    const deployParams = new DeployUtil.DeployParams(publicKey, 'casper');
-
-    const d = DeployUtil.makeDeploy(
-      deployParams,
-      session,
-      DeployUtil.standardPayment(1000000)
-    );
-    console.log(DeployUtil.deployToJson(d));
-  });
 });

--- a/src/lib/CLValue/Result.test.ts
+++ b/src/lib/CLValue/Result.test.ts
@@ -10,10 +10,8 @@ import {
   CLListType,
   CLList,
   CLOptionType,
-  CLOption,
-  CLPublicKey
+  CLOption
 } from './index';
-import { RuntimeArgs, decodeBase16, DeployUtil } from '../../index';
 import { Ok, Err, Some } from 'ts-results';
 
 const myTypes = { ok: new CLBoolType(), err: new CLU8Type() };

--- a/src/lib/CLValue/Result.ts
+++ b/src/lib/CLValue/Result.ts
@@ -55,14 +55,14 @@ export class CLResultType<T extends CLType, E extends CLType> extends CLType {
 
 export class CLResultBytesParser extends CLValueBytesParsers {
   toBytes(value: CLResult<CLType, CLType>): ToBytesResult {
-    if (value.data instanceof Ok && value.data.val instanceof CLValue) {
+    if (value.isOk() && value.data.val.isCLValue()) {
       return Ok(
         concat([
           Uint8Array.from([RESULT_TAG_OK]),
           CLValueParsers.toBytes(value.data.val).unwrap()
         ])
       );
-    } else if (value.data instanceof Err) {
+    } else if (value.isError()) {
       return Ok(
         concat([
           Uint8Array.from([RESULT_TAG_ERROR]),
@@ -154,14 +154,14 @@ export class CLResult<T extends CLType, E extends CLType> extends CLValue {
    * Checks if stored value is error
    */
   isError(): boolean {
-    return this.data instanceof Err;
+    return this.data.err && !this.data.ok;
   }
 
   /**
    * Checks if stored value is valid
    */
   isOk(): boolean {
-    return this.data.ok;
+    return this.data.ok && !this.data.err;
   }
 
   clType(): CLType {


### PR DESCRIPTION
## 2.7.9

### Fixed

- Fixed problems with CLResult when it got created using different version of ts-results.