### PR TITLE
Remove dev dependencies from audit

### DIFF
--- a/.github/workflows/ci-casper-client-sdk.yml
+++ b/.github/workflows/ci-casper-client-sdk.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm install
 
       - name: Audits
-        run: npm audit
+        run: npm audit --omit=dev
 
       - name: Lints
         run: npm run lint:ci


### PR DESCRIPTION
### Context
We're auditing dependencies in the CI, and we can ignore audit errors/warnings from `devDependencies` since they won't be included in the published version