### PR TITLE
Fix named ESM imports from the node bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   ### Removed
  -->
 
-### [5.1.1] - 2026-08-31
+### [5.1.1] - 2026-09-02
 
 ### Fixed
 
 - Named imports now work from Node.js ESM: `import { RpcClient, Transaction } from 'casper-js-sdk'` previously threw `SyntaxError: Named export not found`, forcing ESM consumers through `createRequire` or a default-import destructure. The node bundle is now emitted as statically analyzable CommonJS (`commonjs-static` instead of UMD), so Node's loader can see every named export. `require()` consumers are unaffected — the file is still CommonJS with an identical export surface
+
+### Changed
+
+- **`dist/lib.node.js` is no longer a UMD bundle.** It is plain CommonJS, so `require()`, bundlers and every path through the `exports` map behave as before — but loading that file through an AMD loader such as RequireJS, or as a `<script>` tag expecting a browser global, no longer works. Browser and React Native consumers resolve to `dist/lib.web.js` through the `browser` and `exports` conditions, and that bundle is still UMD
 
 ### [5.1.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   ### Removed
  -->
 
+### [5.1.1] - 2026-08-31
+
+### Fixed
+
+- Named imports now work from Node.js ESM: `import { RpcClient, Transaction } from 'casper-js-sdk'` previously threw `SyntaxError: Named export not found`, forcing ESM consumers through `createRequire` or a default-import destructure. The node bundle is now emitted as statically analyzable CommonJS (`commonjs-static` instead of UMD), so Node's loader can see every named export. `require()` consumers are unaffected — the file is still CommonJS with an identical export surface
+
 ### [5.1.0] - 2026-08-11
 
 No runtime or API change — `dist/` behaves exactly as in `5.0.13` and `engines.node` stays `">=18"`. The rest of the release is an internal toolchain update with no effect on consumers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-js-sdk",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-js-sdk",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,16 @@ const common = {
     rules: [
       {
         test: /\.ts?$/,
-        use: 'ts-loader?configFile=tsconfig.build.json',
+        // ESM input (the shipped tsconfig stays commonjs): webpack can only
+        // enumerate exports statically from ESM, which the node bundle's
+        // `commonjs-static` output depends on.
+        use: {
+          loader: 'ts-loader',
+          options: {
+            configFile: 'tsconfig.build.json',
+            compilerOptions: { module: 'esnext', moduleResolution: 'node' }
+          }
+        },
         exclude: /node_modules/
       }
     ]
@@ -37,7 +46,10 @@ const serverConfig = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'lib.node.js',
-    libraryTarget: 'umd'
+    // Not UMD: `commonjs-static` writes exports cjs-module-lexer can parse, so
+    // Node's ESM loader can synthesize named exports for
+    // `import { RpcClient } from 'casper-js-sdk'`.
+    library: { type: 'commonjs-static' }
   },
   externals: [nodeExternals()] // in order to ignore all modules in node_modules folder
 };
@@ -62,7 +74,7 @@ const clientConfig = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      process: 'process/browser'
+      process: 'process/browser.js'
     }),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer']


### PR DESCRIPTION
`import { RpcClient, Transaction } from 'casper-js-sdk'` threw `SyntaxError: Named export not found` under Node's ESM loader, forcing ESM consumers through `createRequire` or a default-import destructure.

The node bundle was emitted as UMD, which assigns exports dynamically. `cjs-module-lexer` cannot enumerate those, so Node synthesized a default export only.

## Changes

- `output.library.type: 'commonjs-static'` for the node bundle (was `libraryTarget: 'umd'`), which emits statically analyzable `exports.X = ...` assignments.
- `ts-loader` compiles with `module: esnext` — webpack can only enumerate exports statically from ESM input. `moduleResolution: node` is pinned alongside it, since `esnext` alone falls back to classic resolution.
- The `process` ProvidePlugin request gains an explicit `.js`, now that the issuer is ESM and resolved as fully specified.
- Version bump to 5.1.1 plus the changelog entry.

## Verification

- `node --input-type=module -e "import { RpcClient, Transaction, PublicKey } from './dist/lib.node.js'"` resolves all three; it failed before the change.
- `require('./dist/lib.node.js')` still returns the same 438 exports as the UMD build — verified by building both revisions and comparing.
- `npm run lint:ci`, `npm run build`, `npm run test:node:unit:node22` (170 passing).